### PR TITLE
fix: Fixing API use for reply_settings and reply

### DIFF
--- a/lib/src/service/tweets/tweets_service.dart
+++ b/lib/src/service/tweets/tweets_service.dart
@@ -798,10 +798,7 @@ class _TweetsService extends BaseService implements TweetsService {
       'for_super_followers_only': forSuperFollowersOnly,
     };
 
-    // (XRayAdamo) It seems twitter does not accept empty reply entry
-    // if not provided - should not be included into body (Twitter API bug?)
-    // or POST will fail
-    if (inReplyToTweetId?.isNotEmpty == true) {
+    if (inReplyToTweetId != null) {
       // TODO(myConsciousness): Fix after implementing recursive null deletion.
       body['reply'] = {'in_reply_to_tweet_id': inReplyToTweetId};
     }

--- a/lib/src/service/tweets/tweets_service.dart
+++ b/lib/src/service/tweets/tweets_service.dart
@@ -796,12 +796,22 @@ class _TweetsService extends BaseService implements TweetsService {
       'text': text,
       'quote_tweet_id': quoteTweetId,
       'for_super_followers_only': forSuperFollowersOnly,
-      'reply_settings': replySetting?.name,
     };
 
-    if (inReplyToTweetId != null) {
+    // (XRayAdamo) It seems twitter does not accept empty reply entry
+    // if not provided - should not be included into body (Twitter API bug?)
+    // or POST will fail
+    if (inReplyToTweetId?.isNotEmpty == true) {
       // TODO(myConsciousness): Fix after implementing recursive null deletion.
       body['reply'] = {'in_reply_to_tweet_id': inReplyToTweetId};
+    }
+
+    // (XRayAdamo) It seems twitter does not accept reply_settings
+    // as empty string or "everyone" so it should  be included onyl if
+    // it is mentionedUsers or following (Twitter API bug?)
+    // or POST will fail
+    if (replySetting != null && replySetting != ReplySetting.everyone) {
+      body['reply_settings'] = replySetting.name;
     }
 
     final response = await super.post(


### PR DESCRIPTION
# 1. Description

<!-- Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

It seems that Twitter API does not allow 
reply to be empty so it should not be included into body or POST will fail
Same goes for reply_settings field. It cannot be empty and somehow should not "everyone". Only if value = mentionedUsers or following then it should be included into body.

Looks like a bug of twitter API or a limitation, but documentation on API does not tell you this.

## 1.1. Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [ X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## 1.2. Breaking Change

<!-- Does your PR require users to manually update their apps to accommodate your change?

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X ] No, this is _not_ a breaking change.

## 1.3. Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->

[issue database]: https://github.com/twitter-dart/twitter-api-v2/issues
[contributor guide]: https://github.com/twitter-dart/twitter-api-v2/blob/main/CONTRIBUTING.md
[style guide]: https://github.com/twitter-dart/twitter-api-v2/blob/main/STYLEGUIDE.md
[conventional commit]: https://conventionalcommits.org
