### PR TITLE
docs: Added Dart lineLength: 80 Rule for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     "editor.defaultFormatter": "vscode.json-language-features"
   },
   "editor.suggestSelection": "first",
+  "dart.lineLength": 80,
   "[dart]": {
     "editor.formatOnSave": true,
     "editor.formatOnType": true,


### PR DESCRIPTION
# 1. Description

Added `dart.lineLength: 80` rule in VSCode `settings.json` to maintain consistency in the formatting across developers.

## 1.1. Checklist

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## 1.2. Breaking Change

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

## 1.3. Related Issues

Fixes #204 

[issue database]: https://github.com/twitter-dart/twitter-api-v2/issues
[contributor guide]: https://github.com/twitter-dart/twitter-api-v2/blob/main/CONTRIBUTING.md
[style guide]: https://github.com/twitter-dart/twitter-api-v2/blob/main/STYLEGUIDE.md
[conventional commit]: https://conventionalcommits.org
