### PR TITLE
feat: Support `variants` field for `MediaData`

### DIFF
--- a/lib/src/service/media/media_data.dart
+++ b/lib/src/service/media/media_data.dart
@@ -13,6 +13,7 @@ import 'organic_media_metrics.dart';
 import 'private_media_metrics.dart';
 import 'promoted_media_metrics.dart';
 import 'public_media_metrics.dart';
+import 'variant.dart';
 
 part 'media_data.freezed.dart';
 part 'media_data.g.dart';
@@ -105,6 +106,14 @@ class MediaData with _$MediaData {
     ///
     /// - Determine total number of views for the video attached to the Tweet.
     PublicMediaMetrics? publicMetrics,
+
+    /// Variants of media attached in the MediaObject.
+    ///
+    /// ## How It Can Be Used
+    ///
+    /// - Each media object may have multiple display or playback variants,
+    /// with different resolutions or formats.
+    List<Variant>? variants,
   }) = _MediaData;
 
   factory MediaData.fromJson(Map<String, Object?> json) =>

--- a/lib/src/service/media/media_data.dart
+++ b/lib/src/service/media/media_data.dart
@@ -112,7 +112,7 @@ class MediaData with _$MediaData {
     /// ## How It Can Be Used
     ///
     /// - Each media object may have multiple display or playback variants,
-    /// with different resolutions or formats.
+    ///   with different resolutions or formats.
     List<Variant>? variants,
   }) = _MediaData;
 

--- a/lib/src/service/media/media_data.freezed.dart
+++ b/lib/src/service/media/media_data.freezed.dart
@@ -100,6 +100,10 @@ mixin _$MediaData {
   /// - Determine total number of views for the video attached to the Tweet.
   PublicMediaMetrics? get publicMetrics => throw _privateConstructorUsedError;
 
+  /// Each media object may have multiple display or playback variants,
+  /// with different resolutions or formats.
+  List<Variant>? get variants => throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $MediaDataCopyWith<MediaData> get copyWith =>
@@ -122,7 +126,8 @@ abstract class $MediaDataCopyWith<$Res> {
       OrganicMediaMetrics? organicMetrics,
       String? previewImageUrl,
       PromotedMediaMetrics? promotedMetrics,
-      PublicMediaMetrics? publicMetrics});
+      PublicMediaMetrics? publicMetrics,
+      List<Variant>? variants});
 
   $PrivateMediaMetricsCopyWith<$Res>? get privateMetrics;
   $OrganicMediaMetricsCopyWith<$Res>? get organicMetrics;
@@ -152,6 +157,7 @@ class _$MediaDataCopyWithImpl<$Res> implements $MediaDataCopyWith<$Res> {
     Object? previewImageUrl = freezed,
     Object? promotedMetrics = freezed,
     Object? publicMetrics = freezed,
+    Object? variants = freezed,
   }) {
     return _then(_value.copyWith(
       key: key == freezed
@@ -202,6 +208,10 @@ class _$MediaDataCopyWithImpl<$Res> implements $MediaDataCopyWith<$Res> {
           ? _value.publicMetrics
           : publicMetrics // ignore: cast_nullable_to_non_nullable
               as PublicMediaMetrics?,
+      variants: variants == freezed
+          ? _value.variants
+          : variants // ignore: cast_nullable_to_non_nullable
+              as List<Variant>?,
     ));
   }
 
@@ -269,7 +279,8 @@ abstract class _$$_MediaDataCopyWith<$Res> implements $MediaDataCopyWith<$Res> {
       OrganicMediaMetrics? organicMetrics,
       String? previewImageUrl,
       PromotedMediaMetrics? promotedMetrics,
-      PublicMediaMetrics? publicMetrics});
+      PublicMediaMetrics? publicMetrics,
+      List<Variant>? variants});
 
   @override
   $PrivateMediaMetricsCopyWith<$Res>? get privateMetrics;
@@ -305,6 +316,7 @@ class __$$_MediaDataCopyWithImpl<$Res> extends _$MediaDataCopyWithImpl<$Res>
     Object? previewImageUrl = freezed,
     Object? promotedMetrics = freezed,
     Object? publicMetrics = freezed,
+    Object? variants = freezed,
   }) {
     return _then(_$_MediaData(
       key: key == freezed
@@ -355,6 +367,10 @@ class __$$_MediaDataCopyWithImpl<$Res> extends _$MediaDataCopyWithImpl<$Res>
           ? _value.publicMetrics
           : publicMetrics // ignore: cast_nullable_to_non_nullable
               as PublicMediaMetrics?,
+      variants: variants == freezed
+          ? _value._variants
+          : variants // ignore: cast_nullable_to_non_nullable
+              as List<Variant>?,
     ));
   }
 }
@@ -374,7 +390,9 @@ class _$_MediaData implements _MediaData {
       this.organicMetrics,
       this.previewImageUrl,
       this.promotedMetrics,
-      this.publicMetrics});
+      this.publicMetrics,
+      final List<Variant>? variants})
+      : _variants = variants;
 
   factory _$_MediaData.fromJson(Map<String, dynamic> json) =>
       _$$_MediaDataFromJson(json);
@@ -470,9 +488,23 @@ class _$_MediaData implements _MediaData {
   @override
   final PublicMediaMetrics? publicMetrics;
 
+  /// Each media object may have multiple display or playback variants,
+  /// with different resolutions or formats.
+  final List<Variant>? _variants;
+
+  /// Each media object may have multiple display or playback variants,
+  /// with different resolutions or formats.
+  @override
+  List<Variant>? get variants {
+    final value = _variants;
+    if (value == null) return null;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
   @override
   String toString() {
-    return 'MediaData(key: $key, type: $type, url: $url, altText: $altText, durationMilliseconds: $durationMilliseconds, height: $height, width: $width, privateMetrics: $privateMetrics, organicMetrics: $organicMetrics, previewImageUrl: $previewImageUrl, promotedMetrics: $promotedMetrics, publicMetrics: $publicMetrics)';
+    return 'MediaData(key: $key, type: $type, url: $url, altText: $altText, durationMilliseconds: $durationMilliseconds, height: $height, width: $width, privateMetrics: $privateMetrics, organicMetrics: $organicMetrics, previewImageUrl: $previewImageUrl, promotedMetrics: $promotedMetrics, publicMetrics: $publicMetrics, variants: $variants)';
   }
 
   @override
@@ -497,7 +529,8 @@ class _$_MediaData implements _MediaData {
             const DeepCollectionEquality()
                 .equals(other.promotedMetrics, promotedMetrics) &&
             const DeepCollectionEquality()
-                .equals(other.publicMetrics, publicMetrics));
+                .equals(other.publicMetrics, publicMetrics) &&
+            const DeepCollectionEquality().equals(other._variants, _variants));
   }
 
   @JsonKey(ignore: true)
@@ -515,7 +548,8 @@ class _$_MediaData implements _MediaData {
       const DeepCollectionEquality().hash(organicMetrics),
       const DeepCollectionEquality().hash(previewImageUrl),
       const DeepCollectionEquality().hash(promotedMetrics),
-      const DeepCollectionEquality().hash(publicMetrics));
+      const DeepCollectionEquality().hash(publicMetrics),
+      const DeepCollectionEquality().hash(_variants));
 
   @JsonKey(ignore: true)
   @override
@@ -544,7 +578,8 @@ abstract class _MediaData implements MediaData {
       final OrganicMediaMetrics? organicMetrics,
       final String? previewImageUrl,
       final PromotedMediaMetrics? promotedMetrics,
-      final PublicMediaMetrics? publicMetrics}) = _$_MediaData;
+      final PublicMediaMetrics? publicMetrics,
+      final List<Variant>? variants}) = _$_MediaData;
 
   factory _MediaData.fromJson(Map<String, dynamic> json) =
       _$_MediaData.fromJson;
@@ -641,6 +676,11 @@ abstract class _MediaData implements MediaData {
   ///
   /// - Determine total number of views for the video attached to the Tweet.
   PublicMediaMetrics? get publicMetrics => throw _privateConstructorUsedError;
+  @override
+
+  /// Each media object may have multiple display or playback variants,
+  /// with different resolutions or formats.
+  List<Variant>? get variants => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$$_MediaDataCopyWith<_$_MediaData> get copyWith =>

--- a/lib/src/service/media/media_data.g.dart
+++ b/lib/src/service/media/media_data.g.dart
@@ -48,6 +48,12 @@ _$_MediaData _$$_MediaDataFromJson(Map json) => $checkedCreate(
                   ? null
                   : PublicMediaMetrics.fromJson(
                       Map<String, Object?>.from(v as Map))),
+          variants: $checkedConvert(
+              'variants',
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) =>
+                      Variant.fromJson(Map<String, Object?>.from(e as Map)))
+                  .toList()),
         );
         return val;
       },
@@ -77,6 +83,7 @@ Map<String, dynamic> _$$_MediaDataToJson(_$_MediaData instance) =>
       'preview_image_url': instance.previewImageUrl,
       'promoted_metrics': instance.promotedMetrics?.toJson(),
       'public_metrics': instance.publicMetrics?.toJson(),
+      'variants': instance.variants?.map((e) => e.toJson()).toList(),
     };
 
 const _$MediaTypeEnumMap = {

--- a/lib/src/service/media/media_field.dart
+++ b/lib/src/service/media/media_field.dart
@@ -40,7 +40,10 @@ enum MediaField implements Serializable {
   width('width'),
 
   /// `altText`
-  altText('alt_text');
+  altText('alt_text'),
+
+  /// `variants`
+  variants('variants');
 
   @override
   final String value;

--- a/lib/src/service/media/variant.dart
+++ b/lib/src/service/media/variant.dart
@@ -1,0 +1,21 @@
+// Copyright 2022 Kato Shinya. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided the conditions.
+
+// Package imports:
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'variant.freezed.dart';
+part 'variant.g.dart';
+
+@freezed
+class Variant with _$Variant {
+  const factory Variant({
+    int? bitRate,
+    String? contentType,
+    String? url,
+  }) = _Variant;
+
+  factory Variant.fromJson(Map<String, Object?> json) =>
+      _$VariantFromJson(json);
+}

--- a/lib/src/service/media/variant.freezed.dart
+++ b/lib/src/service/media/variant.freezed.dart
@@ -1,0 +1,179 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'variant.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Variant _$VariantFromJson(Map<String, dynamic> json) {
+  return _Variant.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Variant {
+  int? get bitRate => throw _privateConstructorUsedError;
+  String? get contentType => throw _privateConstructorUsedError;
+  String? get url => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $VariantCopyWith<Variant> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $VariantCopyWith<$Res> {
+  factory $VariantCopyWith(Variant value, $Res Function(Variant) then) =
+      _$VariantCopyWithImpl<$Res>;
+  $Res call({int? bitRate, String? contentType, String? url});
+}
+
+/// @nodoc
+class _$VariantCopyWithImpl<$Res> implements $VariantCopyWith<$Res> {
+  _$VariantCopyWithImpl(this._value, this._then);
+
+  final Variant _value;
+  // ignore: unused_field
+  final $Res Function(Variant) _then;
+
+  @override
+  $Res call({
+    Object? bitRate = freezed,
+    Object? contentType = freezed,
+    Object? url = freezed,
+  }) {
+    return _then(_value.copyWith(
+      bitRate: bitRate == freezed
+          ? _value.bitRate
+          : bitRate // ignore: cast_nullable_to_non_nullable
+              as int?,
+      contentType: contentType == freezed
+          ? _value.contentType
+          : contentType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      url: url == freezed
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_VariantCopyWith<$Res> implements $VariantCopyWith<$Res> {
+  factory _$$_VariantCopyWith(
+          _$_Variant value, $Res Function(_$_Variant) then) =
+      __$$_VariantCopyWithImpl<$Res>;
+  @override
+  $Res call({int? bitRate, String? contentType, String? url});
+}
+
+/// @nodoc
+class __$$_VariantCopyWithImpl<$Res> extends _$VariantCopyWithImpl<$Res>
+    implements _$$_VariantCopyWith<$Res> {
+  __$$_VariantCopyWithImpl(_$_Variant _value, $Res Function(_$_Variant) _then)
+      : super(_value, (v) => _then(v as _$_Variant));
+
+  @override
+  _$_Variant get _value => super._value as _$_Variant;
+
+  @override
+  $Res call({
+    Object? bitRate = freezed,
+    Object? contentType = freezed,
+    Object? url = freezed,
+  }) {
+    return _then(_$_Variant(
+      bitRate: bitRate == freezed
+          ? _value.bitRate
+          : bitRate // ignore: cast_nullable_to_non_nullable
+              as int?,
+      contentType: contentType == freezed
+          ? _value.contentType
+          : contentType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      url: url == freezed
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Variant implements _Variant {
+  const _$_Variant({this.bitRate, this.contentType, this.url});
+
+  factory _$_Variant.fromJson(Map<String, dynamic> json) =>
+      _$$_VariantFromJson(json);
+
+  @override
+  final int? bitRate;
+  @override
+  final String? contentType;
+  @override
+  final String? url;
+
+  @override
+  String toString() {
+    return 'Variant(bitRate: $bitRate, contentType: $contentType, url: $url)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Variant &&
+            const DeepCollectionEquality().equals(other.bitRate, bitRate) &&
+            const DeepCollectionEquality()
+                .equals(other.contentType, contentType) &&
+            const DeepCollectionEquality().equals(other.url, url));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(bitRate),
+      const DeepCollectionEquality().hash(contentType),
+      const DeepCollectionEquality().hash(url));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_VariantCopyWith<_$_Variant> get copyWith =>
+      __$$_VariantCopyWithImpl<_$_Variant>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_VariantToJson(this);
+  }
+}
+
+abstract class _Variant implements Variant {
+  const factory _Variant(
+      {final int? bitRate,
+      final String? contentType,
+      final String? url}) = _$_Variant;
+
+  factory _Variant.fromJson(Map<String, dynamic> json) = _$_Variant.fromJson;
+
+  @override
+  int? get bitRate => throw _privateConstructorUsedError;
+  @override
+  String? get contentType => throw _privateConstructorUsedError;
+  @override
+  String? get url => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_VariantCopyWith<_$_Variant> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/service/media/variant.g.dart
+++ b/lib/src/service/media/variant.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'variant.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Variant _$$_VariantFromJson(Map json) => $checkedCreate(
+      r'_$_Variant',
+      json,
+      ($checkedConvert) {
+        final val = _$_Variant(
+          bitRate: $checkedConvert('bit_rate', (v) => v as int?),
+          contentType: $checkedConvert('content_type', (v) => v as String?),
+          url: $checkedConvert('url', (v) => v as String?),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'bitRate': 'bit_rate', 'contentType': 'content_type'},
+    );
+
+Map<String, dynamic> _$$_VariantToJson(_$_Variant instance) =>
+    <String, dynamic>{
+      'bit_rate': instance.bitRate,
+      'content_type': instance.contentType,
+      'url': instance.url,
+    };

--- a/test/src/service/media/media_field_test.dart
+++ b/test/src/service/media/media_field_test.dart
@@ -22,5 +22,6 @@ void main() {
     expect(MediaField.type.value, 'type');
     expect(MediaField.url.value, 'url');
     expect(MediaField.width.value, 'width');
+    expect(MediaField.variants, 'variants');
   });
 }

--- a/test/src/service/media/media_field_test.dart
+++ b/test/src/service/media/media_field_test.dart
@@ -22,6 +22,6 @@ void main() {
     expect(MediaField.type.value, 'type');
     expect(MediaField.url.value, 'url');
     expect(MediaField.width.value, 'width');
-    expect(MediaField.variants, 'variants');
+    expect(MediaField.variants.value, 'variants');
   });
 }


### PR DESCRIPTION
# 1. Description

https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/media

## 1.1. Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## 1.2. Breaking Change

- [x] No, this is _not_ a breaking change.

## 1.3. Related Issues

Fixes #265 

<!-- Links -->

[issue database]: https://github.com/twitter-dart/twitter-api-v2/issues
[contributor guide]: https://github.com/twitter-dart/twitter-api-v2/blob/main/CONTRIBUTING.md
[style guide]: https://github.com/twitter-dart/twitter-api-v2/blob/main/STYLEGUIDE.md
[conventional commit]: https://conventionalcommits.org
